### PR TITLE
Changed rewrite rule for asset urls due to Shopify changes

### DIFF
--- a/builder/tasks/others/server.js
+++ b/builder/tasks/others/server.js
@@ -58,7 +58,7 @@ const createServer = async () => {
 		};
 
 		const rewriteRules = [
-			rewriteRule(/(http:|https:)?\/\/cdn\.shopify\.com\/(?<folder>(?!shopifycloud)(?!s\/javascripts)(?!s\/assets\/storefront)\w+\/)+(?<file>(?!shop_events_listener)[-\w^&'@{}[\],$=!#().]+)(\?((v=)?\d+))?/gm, port),
+			rewriteRule(/(http:|https:)?\/\/([-\w.]+)\/(?<folder>(?!shopifycloud)(?!s\/javascripts)(?!s\/assets\/storefront)\w+\/)+(?<file>(?!shop_events_listener)[-\w^&'@{}[\],$=!#().]+)(\?((v=)?\d+))?/gm, port),
 			{
 				match: new RegExp(`(http:|https:)?//${config.shop}`, 'gm'),
 				fn: function (req, res, match) {


### PR DESCRIPTION
Builder stops replacing files when working on localhost. This change fixes the replacement of assets and now the CDN domain is not hardcoded. This solution is unified and works both with the old type of CDNs and with the new one.

Shopify asset URLs changes which will be applied on Jun 22, 2023 - https://changelog.shopify.com/posts/changes-to-asset-urls